### PR TITLE
build: limit size of uploads to PyPi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,13 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/fmu/sim2seis/version.py"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+exclude = ["tests", "tests.*"]
+
 [project]
 name = "fmu-sim2seis"
 description = "sim2seis"


### PR DESCRIPTION
Remove tests and data files in order to limit the upload size to PyPi.