### PR TITLE
Pydantic validation of horizon names on disk (issue #16)

### DIFF
--- a/src/fmu/sim2seis/utilities/sim2seis_config_validation.py
+++ b/src/fmu/sim2seis/utilities/sim2seis_config_validation.py
@@ -219,7 +219,24 @@ class DepthConvertConfig(BaseModel):
     )
 
     @model_validator(mode="after")
-    def check_depth_and_time(self, info: ValidationInfo) -> Self:
+    def check_depth_convert_config(self, info: ValidationInfo) -> Self:
+        """Validate depth/time range consistency and verify horizon files on disk.
+
+        Range checks
+        ------------
+        - ``max_depth`` must be positive and greater than ``min_depth``, and the
+          range must be divisible by ``z_inc``.
+        - Same constraints apply to the time equivalents.
+
+        Horizon file checks
+        -------------------
+        Each name in ``horizon_names`` must resolve to an existing file in both
+        ``paths.time_horizon_dir`` (with ``time_suffix``) and
+        ``paths.depth_horizon_dir`` (with ``depth_suffix``).
+        ``paths`` is injected via the Pydantic validation context (key ``"paths"``).
+        When no context is provided the file check is skipped.
+        """
+        # --- range consistency ---
         max_depth = self.max_depth
         min_depth = self.min_depth
         z_inc = self.z_inc
@@ -241,6 +258,28 @@ class DepthConvertConfig(BaseModel):
                 raise ValueError("max_time must be greater than min_time")
             if (max_time - min_time) % t_inc != 0:
                 raise ValueError("max_time minus min_time must be divisible by t_inc")
+
+        # --- horizon file existence ---
+        paths = info.context.get("paths") if info and info.context else None
+        if paths:
+            missing: list[str] = []
+            for name in self.horizon_names:
+                lower_name = name.lower()
+
+                time_file = paths.time_horizon_dir / (lower_name + self.time_suffix)
+                if not time_file.is_file():
+                    missing.append(str(time_file))
+
+                depth_file = paths.depth_horizon_dir / (lower_name + self.depth_suffix)
+                if not depth_file.is_file():
+                    missing.append(str(depth_file))
+
+            if missing:
+                missing_list = "\n  ".join(missing)
+                raise ValueError(
+                    f"The following horizon files listed in 'horizon_names' were not "
+                    f"found on disk:\n  {missing_list}"
+                )
 
         return self
 

--- a/tests/test_read_yaml_file.py
+++ b/tests/test_read_yaml_file.py
@@ -1,6 +1,14 @@
+import shutil
 from pathlib import Path
+from typing import ClassVar
+
+import pytest
 
 from fmu.sim2seis.utilities import read_yaml_file
+from fmu.sim2seis.utilities.sim2seis_config_validation import (
+    DepthConvertConfig,
+    Sim2SeisPaths,
+)
 
 
 def test_read_yaml_config(monkeypatch, data_dir):
@@ -36,3 +44,124 @@ def test_read_comb_data_yaml_file(monkeypatch, data_dir):
     # Make some random validations according to default settings
     assert conf.depth_conversion.min_depth < conf.depth_conversion.max_depth
     assert conf.webviz_map.attribute_error == 0.07
+
+
+class TestHorizonFileValidation:
+    """Tests for validation that horizon files exist on disk."""
+
+    _BASE_DATA: ClassVar[dict] = {
+        "depth_suffix": "--depth.gri",
+        "time_suffix": "--time.gri",
+        "min_depth": 1500,
+        "max_depth": 2000,
+        "z_inc": 4,
+        "min_time": 1500,
+        "max_time": 2000,
+        "t_inc": 4,
+    }
+
+    def _make_paths(self, time_dir: Path, depth_dir: Path) -> Sim2SeisPaths:
+        """Build a minimal Sim2SeisPaths with the given horizon directories."""
+        paths = Sim2SeisPaths.model_construct()
+        paths.time_horizon_dir = time_dir
+        paths.depth_horizon_dir = depth_dir
+        return paths
+
+    def _validate(self, horizon_names: list[str], paths: Sim2SeisPaths) -> None:
+        """Run model_validate on DepthConvertConfig, injecting *paths* via context."""
+        DepthConvertConfig.model_validate(
+            {**self._BASE_DATA, "horizon_names": horizon_names},
+            context={"paths": paths},
+        )
+
+    def test_all_horizon_files_present_passes(self, data_dir):
+        """All four horizon names used in the test YAML have matching files."""
+        horizon_dir = data_dir / "share" / "results" / "maps"
+        paths = self._make_paths(horizon_dir, horizon_dir)
+        # Should not raise
+        self._validate(["MSL", "TopVolantis", "BaseVolantis", "BaseVelmodel"], paths)
+
+    def test_missing_time_horizon_raises_value_error(self, data_dir, tmp_path):
+        """A horizon with a missing time file raises a descriptive ValueError."""
+        horizon_dir = data_dir / "share" / "results" / "maps"
+        time_dir = tmp_path / "time_maps"
+        time_dir.mkdir()
+        # Copy all existing files except the time variant of 'TopVolantis'
+        for f in horizon_dir.iterdir():
+            if f.name != "topvolantis--time.gri":
+                (time_dir / f.name).write_bytes(f.read_bytes())
+
+        paths = self._make_paths(time_dir, horizon_dir)
+
+        with pytest.raises(ValueError, match=r"topvolantis--time\.gri"):
+            self._validate(["TopVolantis"], paths)
+
+    def test_missing_depth_horizon_raises_value_error(self, data_dir, tmp_path):
+        """A horizon with a missing depth file raises a descriptive ValueError."""
+        horizon_dir = data_dir / "share" / "results" / "maps"
+        depth_dir = tmp_path / "depth_maps"
+        depth_dir.mkdir()
+        # Copy all existing files except the depth variant of 'BaseVolantis'
+        for f in horizon_dir.iterdir():
+            if f.name != "basevolantis--depth.gri":
+                (depth_dir / f.name).write_bytes(f.read_bytes())
+
+        paths = self._make_paths(horizon_dir, depth_dir)
+
+        with pytest.raises(ValueError, match=r"basevolantis--depth\.gri"):
+            self._validate(["BaseVolantis"], paths)
+
+    def test_multiple_missing_horizons_reported_together(self, tmp_path):
+        """All missing horizon files are reported in a single ValueError."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        paths = self._make_paths(empty_dir, empty_dir)
+
+        with pytest.raises(ValueError) as exc_info:
+            self._validate(["HorizonA", "HorizonB"], paths)
+
+        error_message = str(exc_info.value)
+        assert "horizona--time.gri" in error_message
+        assert "horizona--depth.gri" in error_message
+        assert "horizonb--time.gri" in error_message
+        assert "horizonb--depth.gri" in error_message
+
+    def test_no_context_skips_check(self):
+        """When no validation context is provided the file check is skipped."""
+        # model_validate without context — directories don't exist, but no error raised
+        DepthConvertConfig.model_validate(
+            {**self._BASE_DATA, "horizon_names": ["NonExistentHorizon"]}
+        )
+
+    def test_horizon_validation_triggered_via_read_yaml_file(
+        self, monkeypatch, data_dir, tmp_path
+    ):
+        """Horizon file validation is triggered during full YAML parsing."""
+        config_dir = data_dir / "sim2seis" / "model"
+        monkeypatch.chdir(config_dir)
+
+        # Build a temporary maps directory that is missing one horizon file
+        maps_dir = tmp_path / "maps"
+        shutil.copytree(data_dir / "share" / "results" / "maps", maps_dir)
+        (maps_dir / "msl--time.gri").unlink()
+
+        # Patch Sim2SeisPaths so that time_horizon_dir and depth_horizon_dir point
+        # to our incomplete maps directory, while keeping other paths valid.
+        original_validate = Sim2SeisPaths.model_validate
+
+        def patched_validate(data, **kwargs):
+            obj = original_validate(data, **kwargs)
+            obj.time_horizon_dir = maps_dir
+            obj.depth_horizon_dir = maps_dir
+            return obj
+
+        monkeypatch.setattr(Sim2SeisPaths, "model_validate", patched_validate)
+
+        with pytest.raises(ValueError, match=r"msl--time\.gri"):
+            read_yaml_file(
+                sim2seis_config_dir=config_dir,
+                sim2seis_config_file=Path("sim2seis_config.yml"),
+                global_config_dir=Path("../../fmuconfig/output"),
+                global_config_file=Path("global_variables.yml"),
+                parse_inputs=True,
+            )


### PR DESCRIPTION
For each name in depth_conversion.horizon_names the model validator now checks that both the time and depth horizon files exist on disk before the sim2seis run proceeds.

- Merged the file-existence check into the existing check_depth_and_time validator (renamed check_depth_convert_config) on DepthConvertConfig, since Pydantic only allows one mode='after' model_validator per class.
- paths is injected via the validation context, consistent with the pattern used by SeismicForward.check_seismic_fwd.
- All missing files are collected and reported in a single ValueError.
- Six new tests added in TestHorizonFileValidation.

Fixes #16 