### PR TITLE
Reduce the number of decimals in `ERT` output files

### DIFF
--- a/src/fmu/sim2seis/utilities/export_with_dataio.py
+++ b/src/fmu/sim2seis/utilities/export_with_dataio.py
@@ -126,6 +126,14 @@ def attribute_export(
                     zone=zone_def,
                 )
                 meta_data = Path(export_obj.export(attr_df))
+                # Probably a long-lived temporary fix: ExportData.export does not
+                # handle any kwarg for the DataFrame.to_csv method that is used in the
+                # end. For that reason a call to attr_df.to_csv is added to format the
+                # output. This will reduce the size of the .csv files from the default.
+                # Format is overridden for "REGION" from float to int
+                if "REGION" in attr_df.columns:
+                    attr_df["REGION"] = attr_df["REGION"].astype(int)
+                attr_df.to_csv(meta_data, float_format="%.3f", index=False)
                 with restore_dir(output_path):
                     # Construct file names for output to webviz and ert
                     ert_filename = meta_data.name.replace(".csv", ".txt")


### PR DESCRIPTION
## PR: Reduce decimal precision in ERT/webviz output files

Fixes #108

### Summary

Trims the float precision in the CSV/TXT files emitted by `attribute_export` so that downstream ERT and webviz artifacts are substantially smaller without losing meaningful precision for attribute maps.

### Changes

[src/fmu/sim2seis/utilities/export_with_dataio.py](src/fmu/sim2seis/utilities/export_with_dataio.py)

- After `export_obj.export(attr_df)` writes the dataio CSV, rewrite the same file with `attr_df.to_csv(meta_data, float_format="%.3f")` to apply explicit float formatting. This is a workaround because `dataio.ExportData.export()` does not currently expose a `float_format` / `to_csv` kwarg passthrough.
- Cast `REGION` to `int` before the rewrite so it stays an integer column rather than being formatted as `%.3f`.
- ERT `.txt` output: change `float_format` from `%.6f` to `%.3g`, giving more compact values while preserving significant figures.

### Notes

- The CSV rewrite preserves the dataio-written metadata sidecar (we only overwrite the data file at `meta_data`).
- Marked in-code as a likely long-lived temporary fix; the cleaner solution is upstream support in `fmu-dataio` for passing CSV kwargs through `ExportData.export()`. If/when that lands, the local rewrite block can be removed.

### Verification

- `pytest tests/`: all tests pass.
- `ruff format src/fmu/sim2seis/utilities/export_with_dataio.py`: no changes needed.
- `ruff check src/fmu/sim2seis/utilities/export_with_dataio.py`: all checks passed.
- spot-check: inspect a produced `.csv` and `.txt` to confirm reduced precision and that `REGION` is written as an integer.

### Output of old and new format

```shell
st-lintgx0320.st.statoil.no(hfle) -/tables 13> head topvolantis--relai_full_rms_depth--20200701_20180101.csv
X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
461537.48874362104,5926636.040951573,0.006607670712954717,0.00046253694990683027,1.0
461462.8882845305,5926765.592466002,0.004461583405498283,0.00031231083838487985,1.0
461388.28782543994,5926895.143980431,0.006590220701825765,0.00046131544912780364,1.0
461313.6873663494,5927024.69549486,0.007109878926634579,0.0004976915248644205,1.0
461239.08690725884,5927154.2470092885,0.006545574854867752,0.0004581902398407427,1.0
461164.4864481683,5927283.798523718,0.005287370626640166,0.0003701159438648117,1.0
461089.88598907774,5927413.350038147,0.00360156247178668,0.0002521093730250677,1.0
461015.2855299872,5927542.901552576,0.0036539549199308156,0.00025577684439515713,1.0
460940.68507089664,5927672.453067005,0.002943554714852273,0.00020604883003965915,1.0
st-lintgx0320.st.statoil.no(hfle) -/tables 15> ls -l  topvolantis--relai_full_rms_depth--20200701_20180101.csv
-rw-rw---- 1 hfle fmu 188042 Mar 18 07:32 topvolantis--relai_full_rms_depth--20200701_20180101.csv
```

```shell
st-lintgx0320.st.statoil.no(hfle) -/tables 26> head topvolantis--relai_full_rms_depth--20200701_20180101.csv
X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
461537.489,5926636.041,0.010,0.005,1
461462.888,5926765.592,0.004,0.005,1
461388.288,5926895.144,0.010,0.005,1
461313.687,5927024.695,0.011,0.005,1
461239.087,5927154.247,0.011,0.005,1
461164.486,5927283.799,0.009,0.005,1
461089.886,5927413.350,0.008,0.005,1
461015.286,5927542.902,0.008,0.005,1
460940.685,5927672.453,0.005,0.005,1
st-lintgx0320.st.statoil.no(hfle) -/tables 28> ls -l  topvolantis--relai_full_rms_depth--20200701_20180101.csv
-rw-rw---- 1 hfle hfle 93342 May 26 07:27 topvolantis--relai_full_rms_depth--20200701_20180101.csv
```


Fixes #108

