### PR TITLE
fix: add parquet file format export

### DIFF
--- a/src/fmu/sim2seis/utilities/export_with_dataio.py
+++ b/src/fmu/sim2seis/utilities/export_with_dataio.py
@@ -127,16 +127,26 @@ def attribute_export(
                 )
                 meta_data = Path(export_obj.export(attr_df))
                 with restore_dir(output_path):
-                    # Construct file names for output to webviz and ert
-                    ert_filename = meta_data.name.replace(".csv", ".txt")
-                    webviz_filename = "--".join(["meta", ert_filename])
-                    if Path(webviz_filename).exists():
+                    # Construct file names for output to webviz and ert.
+                    # These are bare basenames, written into the current
+                    # ``output_path`` cwd established by ``restore_dir`` above.
+                    # Using ``Path`` ensures only the suffix is replaced and
+                    # avoids accidentally rewriting an inner ``.csv`` substring.
+                    ert_filename = Path(meta_data.name).with_suffix(".txt")
+                    webviz_filename = ert_filename.with_name(
+                        "meta--" + ert_filename.name
+                    )
+                    parquet_filename = ert_filename.with_suffix(".parquet")
+                    # ``exists()`` follows symlinks, so a broken symlink would
+                    # be missed and the subsequent ``symlink`` call would then
+                    # fail with ``FileExistsError``; ``is_symlink`` catches that
+                    # case as well.
+                    if webviz_filename.exists() or webviz_filename.is_symlink():
                         try:  # noqa: SIM105
-                            unlink(Path(webviz_filename))
+                            unlink(webviz_filename)
                         except FileNotFoundError:
                             pass
-                    symlink(src=meta_data, dst=Path(webviz_filename))
-                    # attr_df.to_csv(webviz_filename, index=False)
+                    symlink(src=meta_data, dst=webviz_filename)
                     # Modelled data will not have observation error
                     columns = ["OBS", "OBS_ERROR"] if is_observed else ["OBS"]
                     attr_df.to_csv(
@@ -146,6 +156,18 @@ def attribute_export(
                         sep=" ",
                         float_format="%.6f",
                         columns=columns,
+                    )
+                    # Parquet copy of the same dataframe for downstream consumers.
+                    # Floats are downcast to float32 (~7 significant digits) to
+                    # cut file size; integer columns are preserved. UTM columns
+                    # fit comfortably as long as sub-decimetre precision is not
+                    # required.
+                    float_cols = attr_df.select_dtypes(include="floating").columns
+                    attr_df.astype(dict.fromkeys(float_cols, "float32")).to_parquet(
+                        parquet_filename,
+                        engine="pyarrow",
+                        compression="zstd",
+                        index=False,
                     )
 
 

--- a/tests/test_run_sim2seis_ci.py
+++ b/tests/test_run_sim2seis_ci.py
@@ -227,6 +227,28 @@ def run_test_sim2seis_map(monkeypatch, data_dir):
         else:
             assert isclose(value, truth_value, atol=a_tol, rtol=r_tol)
 
+    # Parquet companion files are written next to the dataio CSVs.
+    parquet_files = [
+        Path(
+            "share/results/tables/topvolantis--amplitude_full_mean_depth--20200701_20180101.parquet"
+        ),
+        Path(
+            "share/results/tables/topvolantis--relai_full_mean_depth--20200701_20180101.parquet"
+        ),
+    ]
+    for parquet_file in parquet_files:
+        assert parquet_file.exists(), f"Missing parquet output: {parquet_file}"
+        pq_df = pd.read_parquet(parquet_file, engine="pyarrow")
+        csv_df = pd.read_csv(parquet_file.with_suffix(".csv"))
+        # All floating columns must be float32; integer columns must stay integer.
+        for col in pq_df.select_dtypes(include="floating").columns:
+            assert pq_df[col].dtype == "float32"
+        for col in csv_df.select_dtypes(include="integer").columns:
+            assert pd.api.types.is_integer_dtype(pq_df[col])
+        # Same shape and column set as the CSV.
+        assert list(pq_df.columns) == list(csv_df.columns)
+        assert len(pq_df) == len(csv_df)
+
 
 def test_pickle_cleanup_main_script(monkeypatch, data_dir):
     monkeypatch.chdir(data_dir)


### PR DESCRIPTION
### Title
`feat(map_attributes): add float32 parquet companion to attribute-map dataframe export`

Fixes #110 
Fixes #108 

### Summary
Adds a parquet copy of the per-attribute sampled-attribute dataframe written by `attribute_export`, alongside the existing dataio CSV, webviz symlink, and ERT `.txt`. Floating-point columns are downcast to `float32` and the file is zstd-compressed; integer columns are preserved.

### Changes

`src/fmu/sim2seis/utilities/export_with_dataio.py`
- New parquet output next to the existing dataio CSV per `(attribute, calc)` iteration:
  - `engine="pyarrow"`, `compression="zstd"`, `index=False`.
  - Floating-point columns downcast to `float32` via `dict.fromkeys(float_cols, "float32")`.
  - Integer columns left untouched.
  - Inline comment noting the float32 / UTM precision tradeoff (~7 significant digits; sub-decimetre coordinates fit).
- Filename construction switched from `str.replace(".csv", ...)` on `meta_data.name` to `Path` operations on the basename only:
  - `ert_filename = Path(meta_data.name).with_suffix(".txt")`
  - `webviz_filename = ert_filename.with_name("meta--" + ert_filename.name)`
  - `parquet_filename = ert_filename.with_suffix(".parquet")`
  - This guarantees only the trailing suffix is rewritten (avoids accidental rewrite of an inner `.csv` substring) while keeping all three as bare basenames written into the `restore_dir(output_path)` cwd.
- Removed a dead commented `attr_df.to_csv(webviz_filename, …)` line that would have written through the webviz symlink and silently overwritten the dataio CSV.

`tests/test_run_sim2seis_ci.py`
- Extended `run_test_sim2seis_map` to assert, for both amplitude and relai map outputs:
  - the `.parquet` companion exists next to the dataio CSV,
  - all floating columns have dtype `float32`,
  - integer columns remain integer,
  - column set and row count match the sibling CSV.

### Rationale
- Parquet gives downstream consumers a typed, binary, compressed alternative to the CSV without changing existing outputs.
- `float32` + zstd substantially reduces on-disk size while staying well within the precision the attribute maps actually carry.
- Keeping integer columns at their native dtype avoids accidental widening / precision loss for IDs such as `REGION` / `ZONE`.
- `Path`-based filename construction is more defensive than `str.replace` against future filenames containing inner suffix-like substrings.

### Risk / compatibility
- Pure addition for the parquet output: no existing file is renamed, removed, or changed in content. Existing consumers of the CSV/TXT outputs are unaffected.
- Filename construction refactor is behaviourally equivalent for current dataio filenames; intermediate iterations that produced full-path or path-joined names have been corrected.
- Adds an explicit dependency on the `pyarrow` engine and zstd codec, both already pulled in transitively via `fmu-dataio`.

### Verification
- `ruff check` and `ruff format --check` clean on both changed files.
- `pytest tests/test_run_sim2seis_ci.py::test_sim2seis` passes (~90 s), including the new parquet assertions.
- Manual end-to-end run confirmed by reviewer.

### Out of scope / follow-ups
- The pre-existing `symlink(meta_data → webviz_filename)` pattern remains; if a future change re-enables a write to `webviz_filename`, it must avoid writing through the symlink (would overwrite the dataio CSV).