### PR TITLE
Fix/simulator and pem names modified

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,6 +111,17 @@ Scope examples: `validation`, `ert`, `seismic_fwd`, `observed_data`.
 
 Use atomic commits — one logical change per commit.
 
+## Pull request summaries
+
+PR summaries (titles, descriptions, review comments) must be:
+
+- **Brief** — no filler, no recap of obvious diff content.
+- **Covering** — mention every user-visible change and any non-obvious
+  rationale, so a reviewer can grasp the scope without reading every hunk.
+- **Written in Markdown** — use fenced code blocks for commands, paths, and
+  identifiers; use short bullet lists for change inventories; use headings only
+  when the PR spans multiple distinct areas.
+
 ## Testing guidelines
 
 - Test data is under `tests/data/`; use the `data_dir` / `testdata` fixtures

--- a/documentation/docs/input-output.md
+++ b/documentation/docs/input-output.md
@@ -100,9 +100,9 @@ changed to `observations`.
 | ------------- | ----------- | ---- |
 | Global config | `./fmuconfig/output` | `global_variables.yml` / `global_variables_pred.yml` |
 | Configuration file | `./sim2seis/model` | `pem_config.yml` |
-| Eclipse grid definition | `./sim2seis/input/pem` | `ECLIPSE.EGRID` |
-| Eclipse init properties | `./sim2seis/input/pem` | `ECLIPSE.INIT` |
-| Eclipse restart properties | `./sim2seis/input/pem` | `ECLIPSE.UNRST` |
+| Reservoir simulator grid definition | `./sim2seis/input/pem` | `ECLIPSE.EGRID` |
+| Reservoir simulator init properties | `./sim2seis/input/pem` | `ECLIPSE.INIT` |
+| Reservoir simulator restart properties | `./sim2seis/input/pem` | `ECLIPSE.UNRST` |
 | NTG property – optional | `./sim2seis/input/pem` | `grid--ntg_pem.roff` |
 | Volume fraction grid definition | `./sim2seis/input/pem` | `export_grid.grdecl` |
 | Volume fraction sets | `./sim2seis/input/pem` | `export_prop.grdecl` |

--- a/documentation/docs/qc.md
+++ b/documentation/docs/qc.md
@@ -6,9 +6,9 @@ QC should include:
   that an input has been provided with an unexpected unit (it is generally assumed that all inputs use SI units).
 - `pem` can be configured to save intermediate results, such as effective mineral and fluid properties. These represent
   the initial step in the process and can serve as the first point of verification.
-- Inputs should also be validated, i.e., the `eclipse` `.INIT` and `.UNRST` files, as well as volume fraction grids
-  from the geomodel. For example, low-pressure outliers in `eclipse` runs can lead to errors in fluid property
-  estimation.
+- Inputs should also be validated, i.e., the reservoir simulator `.INIT` and `.UNRST` files, as well as volume
+  fraction grids from the geomodel. For example, low-pressure outliers in reservoir simulator runs can lead to errors
+  in fluid property estimation.
 - Comparison between the primary influencing factors of 4D response, i.e., changes in pressure and saturation, correlated
   to the seismic amplitude or relative acoustic impedance response.
 

--- a/documentation/docs/qc_resinsight.md
+++ b/documentation/docs/qc_resinsight.md
@@ -11,7 +11,7 @@ for attribute maps and horizons that are common to both `xtgeo` and ResInsight.
 It is possible to import grids and grid properties in `.roff` format. Grids and grid properties can be imported into a
 ResInsight project in one operation, or the grid properties can be added after the grid is imported.
 
-Eclipse simulation runs can also be used to define the grid, and the results from `pem` can be added as properties. This
+Reservoir simulator simulation runs can also be used to define the grid, and the results from `pem` can be added as properties. This
 enables cross-plotting of static and dynamic properties that are input to `pem` with `pem` results, allowing
 verification of their expected relationships.
 
@@ -35,9 +35,9 @@ as colour legends, property filters, annotations, etc.
 ### Grid Analysis
 
 There are multiple options for grid analysis in ResInsight. Cross-plots between grid properties, i.e. results from `pem`
-can be combined with `eclipse` `init` or `unrst` (static or dynamic) properties. Cross-plots are part of the Plot
-Window options in ResInsight. Histogram of grids and cumulative histogram can be found in either the Plot Window, or
-as a right-click option in the 3D display background.
+can be combined with reservoir simulator `INIT` or `UNRST` (static or dynamic) properties. Cross-plots are part of the
+Plot Window options in ResInsight. Histogram of grids and cumulative histogram can be found in either the Plot Window,
+or as a right-click option in the 3D display background.
 
 ![Grid histogram](./images/Drogon_PEM_grid_3D_View_eclipse_ai_20180701_Statistics.png)
 <span id="figure-3-grid-histogram"></span>

--- a/documentation/docs/qc_resinsight.md
+++ b/documentation/docs/qc_resinsight.md
@@ -11,7 +11,7 @@ for attribute maps and horizons that are common to both `xtgeo` and ResInsight.
 It is possible to import grids and grid properties in `.roff` format. Grids and grid properties can be imported into a
 ResInsight project in one operation, or the grid properties can be added after the grid is imported.
 
-Reservoir simulator simulation runs can also be used to define the grid, and the results from `pem` can be added as properties. This
+Reservoir simulator runs can also be used to define the grid, and the results from `pem` can be added as properties. This
 enables cross-plotting of static and dynamic properties that are input to `pem` with `pem` results, allowing
 verification of their expected relationships.
 

--- a/documentation/docs/qc_rms.md
+++ b/documentation/docs/qc_rms.md
@@ -86,8 +86,8 @@ rel_dir_mod_grid = r"share/results/grids"
 
 # Grid property import from PEM. NB! Grid model must exist before import
 os.chdir(project_dir + os.path.sep + rel_dir_mod_grid)
-pem_grid_name = "Eclipsegrid_pem"
-pem_grid_prop_ai_name = "eclipsegrid_pem--airatio--20180701_20180101.roff"
+pem_grid_name = "simgrid"
+pem_grid_prop_ai_name = "simgrid--airatio--20180701_20180101.roff"
 pem_ai = xtgeo.gridproperty_from_file(pem_grid_prop_ai_name, fformat="roff")
 pem_ai.to_roxar(projectname=PRJ, gridname=pem_grid_name, propertyname=pem_grid_prop_ai_name[:-4])
 

--- a/tests/data/sim2seis/output/pem/eclipsegrid_pem.grdecl
+++ b/tests/data/sim2seis/output/pem/eclipsegrid_pem.grdecl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cb202028c03e94d8742e800ce72ae666fbb9e1c76b57ff949b79a36c6241d14
-size 16224037


### PR DESCRIPTION
Generalises documentation wording so it no longer implies the
reservoir simulator is Eclipse, and aligns the example PEM output grid
prefix with the new `simgrid` convention.

### Documentation
- `input-output.md`, `qc.md`, `qc_resinsight.md`: prose changed from
  `eclipse` / `Eclipse simulation runs` to `reservoir simulator`.
  Uppercase input file names (`ECLIPSE.EGRID`, `ECLIPSE.INIT`,
  `ECLIPSE.UNRST`) are intentionally kept.
- `qc_rms.md`: xtgeo example uses `simgrid` and
  `simgrid--airatio--<dates>.roff`.

### Test fixtures
- Removed stale `tests/data/sim2seis/output/pem/eclipsegrid_pem.grdecl`
  — not referenced by any test or source module after the PEM prefix
  change.

### Tooling
- `.github/copilot-instructions.md`: added a "Pull request summaries"
  section requiring brief, covering, Markdown-formatted summaries.

### Out of scope (intentionally not changed)
- `<eclipse-file>` and `<fixed-triangularization-of-eclipse-grid>` in
  `tests/data/sim2seis/model/model_file*.xml` — these are tags from the
  external `seismic-forward` XML schema.
- `ECLGRIDNAME*` and `ECLIPSE_*` template variables in
  `tests/data/fmuconfig/output/global_variables*.yml(.tmpl)` — consumed
  by sibling FMU tools, not by `fmu-sim2seis`.
- `documentation/docs/images/Drogon_PEM_grid_3D_View_eclipse_ai_..png`
  — the `eclipse_ai` substring is baked into the ResInsight screenshot
  itself; renaming the file would not change the visible title.