### PR TITLE
Fix/attribute zone name

### DIFF
--- a/documentation/docs/ert.tmLanguage.json
+++ b/documentation/docs/ert.tmLanguage.json
@@ -12,7 +12,7 @@
         {"include": "#entities"},
         {"include": "#endcomments"},
         {"include": "#numbers"},
-        {"include": "#symbols"},
+        {"include": "#symbols"}
     ],
     "repository": {
         "keywords": {
@@ -22,7 +22,7 @@
             "patterns": [
                 {
                     "name": "entity.name.function.ert",
-                    "match": "[A-Z0-9][._A-Z0-9]*(?=\\()",
+                    "match": "[A-Z0-9][._A-Z0-9]*(?=\\()"
                 }
             ]
         },
@@ -30,7 +30,7 @@
             "patterns": [
                 {
                     "name": "variable.parameter.ert",
-                    "match": "\\s[$A-Z][_A-Z0-9]*(?=\\s)",
+                    "match": "\\s[$A-Z][_A-Z0-9]*(?=\\s)"
                 }
             ]
         },
@@ -38,7 +38,7 @@
             "patterns": [
                 {
                     "name": "support.type.property-name.json",
-                    "match": "<RUNPATH>|<CONFIG_PATH>",
+                    "match": "<RUNPATH>|<CONFIG_PATH>"
                 }
             ]
         },
@@ -47,9 +47,9 @@
         },
         "strings": {
             "name": "string.quoted.double.ert",
-            "begin": '"',
-            "end": '"',
-            "patterns": [{"name": "constant.character.escape.ert", "match": "\\\\."}],
+            "begin": "\"",
+            "end": "\"",
+            "patterns": [{"name": "constant.character.escape.ert", "match": "\\\\."}]
         },
         "linecomments": {
             "patterns": [{"name": "comment.line.double-dash.ert", "match": "^--.*$"}]
@@ -67,14 +67,14 @@
                         "3": {"name": "meta.delimiter.decimal.period.ert"},
                         "4": {"name": "meta.delimiter.decimal.period.ert"},
                         "5": {"name": "meta.delimiter.decimal.period.ert"},
-                        "6": {"name": "meta.delimiter.decimal.period.ert"},
-                    },
+                        "6": {"name": "meta.delimiter.decimal.period.ert"}
+                    }
                 }
             ]
         },
         "symbols": {
             "patterns": [{"match": "=|\/|\\(|\\)|,", "name": "storage.type.ert"}]
-        },
+        }
     },
-    "scopeName": "source.ert",
+    "scopeName": "source.ert"
 }

--- a/src/fmu/sim2seis/utilities/export_with_dataio.py
+++ b/src/fmu/sim2seis/utilities/export_with_dataio.py
@@ -111,7 +111,7 @@ def attribute_export(
                     ],
                     is_observation=is_observed,
                     preprocessed=is_preprocessed,
-                    name=attr.top_surface.name,
+                    name=attr.formation,
                     tagname=tag_str,
                     vertical_domain=attr.from_cube.cube_name.domain,
                     rep_include=False,

--- a/src/fmu/sim2seis/utilities/interval_parser.py
+++ b/src/fmu/sim2seis/utilities/interval_parser.py
@@ -288,6 +288,7 @@ def _create_seismic_attribute(
     global_config: GlobalConfig,
     cube_info: CubeConfig,
     cube: SeismicCube,
+    formation_name: str,
     error: ErrorConfig | None = None,
 ) -> SeismicAttribute:
     """Create a single SeismicAttribute object for a given interval configuration."""
@@ -321,6 +322,7 @@ def _create_seismic_attribute(
         bottom_surface=attr_bottom_surface,
         top_surface_shift=interval_config.top_surface_shift,
         bottom_surface_shift=interval_config.bottom_surface_shift,
+        formation=formation_name,
         info=cube_info,
         error=error,
     )
@@ -341,6 +343,7 @@ def _create_formation_attributes(
     cubes: CubeDict,
     surfaces: SurfaceDict,
     global_config: GlobalConfig,
+    formation_name: str,
     error: ErrorConfig | None = None,
 ) -> list[SeismicAttribute]:
     """Create SeismicAttribute objects for each interval group and matching cube."""
@@ -355,6 +358,7 @@ def _create_formation_attributes(
                 global_config=global_config,
                 cube_info=cube_info,
                 cube=seismic_cube,
+                formation_name=formation_name,
                 error=error,
             )
             formation_attributes.append(attribute)
@@ -400,6 +404,7 @@ def _process_formation(
         cubes=cubes,
         surfaces=surfaces,
         global_config=global_config,
+        formation_name=formation_name,
         error=error,
     )
 

--- a/src/fmu/sim2seis/utilities/sim2seis_class_definitions.py
+++ b/src/fmu/sim2seis/utilities/sim2seis_class_definitions.py
@@ -399,6 +399,7 @@ class SeismicAttribute:
     bottom_surface: xtgeo.RegularSurface | None = None
     top_surface_shift: float = 0.0  # Use signed values for shift
     bottom_surface_shift: float = 0.0  # Use signed values for shift
+    formation: str | None = None
     info: CubeConfig | None = None
     error: ErrorConfig | None = None
 

--- a/tests/test_run_sim2seis_ci.py
+++ b/tests/test_run_sim2seis_ci.py
@@ -49,16 +49,16 @@ def test_obs_data(monkeypatch, data_dir):
     # Check values in some of the resulting data files against truth values
     test_files = [
         Path(
-            "share/preprocessed/maps/topvolantis--amplitude_full_rms_depth--20200701_20180101.gri"
+            "share/preprocessed/maps/volantis--amplitude_full_rms_depth--20200701_20180101.gri"
         ),
         Path(
-            "share/preprocessed/maps/topvolantis--relai_full_min_depth--20200701_20180101.gri"
+            "share/preprocessed/maps/volantis--relai_full_min_depth--20200701_20180101.gri"
         ),
         Path(
-            "share/preprocessed/tables/topvolantis--amplitude_full_mean_depth--20200701_20180101.csv"
+            "share/preprocessed/tables/volantis--amplitude_full_mean_depth--20200701_20180101.csv"
         ),
         Path(
-            "share/preprocessed/tables/topvolantis--relai_full_rms_depth--20200701_20180101.csv"
+            "share/preprocessed/tables/volantis--relai_full_rms_depth--20200701_20180101.csv"
         ),
     ]
     expected_values = [
@@ -179,16 +179,16 @@ def run_test_sim2seis_map(monkeypatch, data_dir):
     # Check values in some of the resulting data files against truth values
     test_files = [
         Path(
-            "share/results/maps/topvolantis--amplitude_full_rms_depth--20200701_20180101.gri"
+            "share/results/maps/volantis--amplitude_full_rms_depth--20200701_20180101.gri"
         ),
         Path(
-            "share/results/maps/topvolantis--relai_full_min_depth--20200701_20180101.gri"
+            "share/results/maps/volantis--relai_full_min_depth--20200701_20180101.gri"
         ),
         Path(
-            "share/results/tables/topvolantis--amplitude_full_mean_depth--20200701_20180101.csv"
+            "share/results/tables/volantis--amplitude_full_mean_depth--20200701_20180101.csv"
         ),
         Path(
-            "share/results/tables/topvolantis--relai_full_mean_depth--20200701_20180101.csv"
+            "share/results/tables/volantis--relai_full_mean_depth--20200701_20180101.csv"
         ),
         Path("share/results/pickle_files/amplitude_maps_depth_attributes.pkl"),
         Path("share/results/pickle_files/relai_maps_depth_attributes.pkl"),
@@ -214,10 +214,10 @@ def run_test_sim2seis_map(monkeypatch, data_dir):
     # Parquet companion files are written next to the dataio CSVs.
     parquet_files = [
         Path(
-            "share/results/tables/topvolantis--amplitude_full_mean_depth--20200701_20180101.parquet"
+            "share/results/tables/volantis--amplitude_full_mean_depth--20200701_20180101.parquet"
         ),
         Path(
-            "share/results/tables/topvolantis--relai_full_mean_depth--20200701_20180101.parquet"
+            "share/results/tables/volantis--relai_full_mean_depth--20200701_20180101.parquet"
         ),
     ]
     for parquet_file in parquet_files:

--- a/tests/test_run_sim2seis_ert.py
+++ b/tests/test_run_sim2seis_ert.py
@@ -97,16 +97,16 @@ def test_sim2seis_ert(testdata, monkeypatch, data_dir):
         Path("share/results/pickle_files/relai_diff_depth.pkl"),
         Path("share/results/pickle_files/relai_diff_time.pkl"),
         Path(
-            "share/results/maps/topvolantis--amplitude_full_rms_depth--20200701_20180101.gri"
+            "share/results/maps/volantis--amplitude_full_rms_depth--20200701_20180101.gri"
         ),
         Path(
-            "share/results/maps/topvolantis--relai_full_min_depth--20200701_20180101.gri"
+            "share/results/maps/volantis--relai_full_min_depth--20200701_20180101.gri"
         ),
         Path(
-            "share/results/tables/topvolantis--amplitude_full_mean_depth--20200701_20180101.csv"
+            "share/results/tables/volantis--amplitude_full_mean_depth--20200701_20180101.csv"
         ),
         Path(
-            "share/results/tables/topvolantis--relai_full_mean_depth--20200701_20180101.csv"
+            "share/results/tables/volantis--relai_full_mean_depth--20200701_20180101.csv"
         ),
         Path("share/results/pickle_files/amplitude_maps_depth_attributes.pkl"),
         Path("share/results/pickle_files/relai_maps_depth_attributes.pkl"),


### PR DESCRIPTION
## Use formation name for exported attribute maps

### Summary
Exported attribute maps/tables are now named after the **formation** rather than the top-surface horizon, so dataio object names drop the `top` prefix (e.g. `topvolantis--…` → `volantis--…`).

Closes #93 

### Changes
- **`SeismicAttribute`** — added a `formation: str | None = None` field.
- **`interval_parser.py`** — threaded `formation_name` through `_process_formation` → `_create_formation_attributes` → `_create_seismic_attribute`, populating `SeismicAttribute.formation`.
- **`export_with_dataio.py`** — dataio `name` now uses `attr.formation` instead of `attr.top_surface.name`.
- **Tests** (`test_run_sim2seis_ci.py`, `test_run_sim2seis_ert.py`) — updated expected map/table/parquet filenames from `topvolantis--…` to `volantis--…`.

### Rationale
The dataio `name` should reflect the stratigraphic formation, not the top-surface horizon name, giving cleaner and correct exported object names.

### Testing
- all tests pass
- ruff formation and check pass for all files