### PR TITLE
Move observation error settings to the interval definition file

### DIFF
--- a/documentation/docs/attribute-maps.md
+++ b/documentation/docs/attribute-maps.md
@@ -10,7 +10,8 @@ derived from the dedicated interval definition file. [Figure 1](#figure-1-seismi
 sections of the configuration file. `webviz_map` refers to export of attribute maps in formats that can be read by
 `webviz` and `ert` for visualisation and history matching. As most parameters are commented out, this indicates that
 the default settings in most cases are used. It is only the name of the attribute definition file in the
-`main class setting` that must be specified. The settings for attribute error are used for [observed data](./observed-data.md).
+`main class setting` that must be specified. The settings for the observation error are given in the
+[interval definition file](#error-settings) and apply to [observed data](./observed-data.md) only.
 
 ```yaml
 # # Section for ert and webviz export
@@ -19,8 +20,6 @@ webviz_map:
   # grid_file: simgrid_maps4ahm.roff
   # zone_file: simgrid_maps4ahm--zone.roff
   # region_file: simgrid_maps4ahm--region.roff
-  attribute_error: 0.07
-  attribute_error_minimum: 0.005
 
 
 ## Section for seismic forward amplitude maps
@@ -73,6 +72,45 @@ The `global` section defines parameters that apply to all interval definitions u
 - Attributes: Select attributes to highlight important features in the 4D seismic.
 - Scale factor: Used to match values in similar attributes from observed seismic data.
 - Metadata fields: Used in `fmu-dataio`.
+- Error settings: `error` and `error_path` define the observation error, see [Error settings](#error-settings).
+
+### Error settings
+
+The observation error is written as an `OBS_ERROR` column in the exported CSV files and applies to
+[observed data](./observed-data.md) only. It is defined by an `error` block with the following fields:
+
+- `type`: `relative` (a fraction of the attribute value) or `absolute` (the error itself).
+- `value`: a single scalar error, or
+- `error_surface`: the name of a spatially varying error map, resolved against the global `error_path`. The file is
+  read with `xtgeo` and must have the same geometry as the attribute maps. Exactly one of `value` or `error_surface`
+  must be given.
+- `minimum`: an absolute floor applied after the error is computed (default `0.0`).
+
+All four combinations of `type` and source (scalar `value` or `error_surface`) are supported. The `error_path`
+directory is set once, in the `global` section only.
+
+The `error` block can be given at the `global`, cube, or formation level. A block at a more specific level fully
+replaces the one at the level above it (whole-block replacement); individual fields are not merged. For example:
+
+```yaml
+global:
+  error_path: share/results/maps
+  error:
+    type: relative
+    value: 0.07
+    minimum: 0.005
+cubes:
+  relai_depth:
+    error: # replaces the global error for this cube
+      type: absolute
+      error_surface: relai_error.gri
+      minimum: 0.005
+    formations:
+      volantis:
+        error: # replaces the cube/global error for this formation
+          type: relative
+          value: 0.05
+```
 
 ### Cube Section
 

--- a/src/fmu/sim2seis/utilities/export_with_dataio.py
+++ b/src/fmu/sim2seis/utilities/export_with_dataio.py
@@ -1,6 +1,7 @@
 from os import symlink, unlink
 from pathlib import Path
 
+import numpy as np
 import xtgeo
 
 from fmu import dataio, tools
@@ -8,6 +9,7 @@ from fmu.pem.pem_utilities import restore_dir
 
 from .sim2seis_class_definitions import (
     DifferenceSeismic,
+    ErrorConfig,
     SeismicAttribute,
     SeismicName,
     SingleSeismic,
@@ -116,12 +118,21 @@ def attribute_export(
                     table_index=["REGION"],
                 )
                 export_obj.export(value)  # type: ignore
-                # Make ert/webviz dataframe
+                # Make ert/webviz dataframe. Observation error only applies to
+                # observed data; modelled data are written without error.
+                if is_observed and attr.error is not None:
+                    attribute_error: xtgeo.RegularSurface | float = (
+                        _build_error_surface(value, attr.error)
+                    )
+                    attribute_error_minimum = attr.error.minimum or None
+                else:
+                    attribute_error = 0.0
+                    attribute_error_minimum = None
                 attr_df = tools.sample_attributes_for_sim2seis(
                     grid=simgrid,
                     attribute=value,
-                    attribute_error=config_file.webviz_map.attribute_error,
-                    attribute_error_minimum=config_file.webviz_map.attribute_error_minimum,
+                    attribute_error=attribute_error,
+                    attribute_error_minimum=attribute_error_minimum,
                     region=region_def,
                     zone=zone_def,
                 )
@@ -169,6 +180,35 @@ def attribute_export(
                         compression="zstd",
                         index=False,
                     )
+
+
+def _build_error_surface(
+    attribute_map: xtgeo.RegularSurface,
+    error: ErrorConfig,
+) -> xtgeo.RegularSurface:
+    """Build an absolute observation-error surface for an attribute map.
+
+    Supports the four combinations of {relative, absolute} error given either
+    as a single scalar ``value`` or as a spatially varying ``error_surface``.
+    A relative error is multiplied by the attribute values; an absolute error
+    is used directly. The error surface is imported with xtgeo and must share
+    the geometry of the attribute maps.
+    """
+    if error.error_surface is not None:
+        err = xtgeo.surface_from_file(error.error_surface)
+        if not err.compare_topology(attribute_map):
+            raise ValueError(
+                f"Error surface '{error.error_surface}' does not have the same "
+                "geometry as the attribute maps."
+            )
+    else:
+        err = attribute_map.copy()
+        err.values = error.value
+
+    if error.type == "relative":
+        err.values = attribute_map.values * err.values
+    err.values = np.abs(err.values)
+    return err
 
 
 def _get_grid_info(

--- a/src/fmu/sim2seis/utilities/interval_parser.py
+++ b/src/fmu/sim2seis/utilities/interval_parser.py
@@ -93,7 +93,7 @@ class RootConfig(BaseModel):
             )
 
         for error in surface_errors:
-            full_path = self.global_config.error_path / error.error_surface
+            full_path = (self.global_config.error_path / error.error_surface).resolve()
             if not full_path.is_file():
                 raise ValueError(f"Error surface file not found: {full_path}")
             # ErrorConfig is frozen; normalise the field to the absolute path.

--- a/src/fmu/sim2seis/utilities/interval_parser.py
+++ b/src/fmu/sim2seis/utilities/interval_parser.py
@@ -22,6 +22,7 @@ from pydantic_core import PydanticCustomError
 
 from .sim2seis_class_definitions import (
     DifferenceSeismic,
+    ErrorConfig,
     KnownAttributes,
     SeismicAttribute,
     SeismicName,
@@ -50,6 +51,8 @@ class GlobalConfig(BaseModel):
     attributes: list[KnownAttributes]
     surface_postfix: str
     scale_factor: float
+    error: ErrorConfig | None = None
+    error_path: DirectoryPath | None = None
 
 
 class RootConfig(BaseModel):
@@ -57,6 +60,45 @@ class RootConfig(BaseModel):
 
     global_config: GlobalConfig = Field(alias="global")
     cubes: dict[str, CubeConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def resolve_error_surfaces(self) -> RootConfig:
+        """Validate and resolve every ``error_surface`` in the configuration.
+
+        Error blocks may appear at the global, cube, and formation level. Any
+        ``error_surface`` name is resolved against the single global
+        ``error_path`` and its existence is verified. The resolved absolute
+        path is stored back on the error block so consumers do not need the
+        directory.
+        """
+        error_blocks = [self.global_config.error]
+        for cube in self.cubes.values():
+            error_blocks.append(cube.error)
+            error_blocks.extend(
+                formation.error for formation in cube.formations.values()
+            )
+
+        surface_errors = [
+            error
+            for error in error_blocks
+            if error is not None and error.error_surface is not None
+        ]
+        if not surface_errors:
+            return self
+
+        if self.global_config.error_path is None:
+            raise ValueError(
+                "An 'error_surface' is configured but 'error_path' is not set "
+                "in the global section of the interval definition file."
+            )
+
+        for error in surface_errors:
+            full_path = self.global_config.error_path / error.error_surface
+            if not full_path.is_file():
+                raise ValueError(f"Error surface file not found: {full_path}")
+            # ErrorConfig is frozen; normalise the field to the absolute path.
+            object.__setattr__(error, "error_surface", full_path)
+        return self
 
 
 class FormationSettings(BaseModel):
@@ -68,6 +110,7 @@ class FormationSettings(BaseModel):
     top_surface_shift: float = 0
     bottom_surface_shift: float = 0
     window_length: float | None = None
+    error: ErrorConfig | None = None
 
     attribute_overrides: dict[KnownAttributes, dict[str, Any]] = Field(
         default_factory=dict, exclude=True
@@ -120,6 +163,7 @@ class CubeConfig(BaseModel):
 
     cube_prefix: str
     formations: dict[str, FormationSettings]
+    error: ErrorConfig | None = None
 
 
 class IntervalConfig(BaseModel):
@@ -244,6 +288,7 @@ def _create_seismic_attribute(
     global_config: GlobalConfig,
     cube_info: CubeConfig,
     cube: SeismicCube,
+    error: ErrorConfig | None = None,
 ) -> SeismicAttribute:
     """Create a single SeismicAttribute object for a given interval configuration."""
     # Pydantic validation in IntervalConfig ensures top_horizon is always set
@@ -277,6 +322,7 @@ def _create_seismic_attribute(
         top_surface_shift=interval_config.top_surface_shift,
         bottom_surface_shift=interval_config.bottom_surface_shift,
         info=cube_info,
+        error=error,
     )
 
 
@@ -295,6 +341,7 @@ def _create_formation_attributes(
     cubes: CubeDict,
     surfaces: SurfaceDict,
     global_config: GlobalConfig,
+    error: ErrorConfig | None = None,
 ) -> list[SeismicAttribute]:
     """Create SeismicAttribute objects for each interval group and matching cube."""
     formation_attributes = []
@@ -308,9 +355,25 @@ def _create_formation_attributes(
                 global_config=global_config,
                 cube_info=cube_info,
                 cube=seismic_cube,
+                error=error,
             )
             formation_attributes.append(attribute)
     return formation_attributes
+
+
+def _resolve_error_block(
+    global_config: GlobalConfig,
+    cube_info: CubeConfig,
+    formation_settings: FormationSettings,
+) -> ErrorConfig | None:
+    """Select the observation error for a formation.
+
+    The most specific error block wins (whole-block replacement): formation
+    overrides cube, which overrides the global setting. ``error_surface`` paths
+    have already been validated and resolved to absolute paths by
+    ``RootConfig.resolve_error_surfaces``.
+    """
+    return formation_settings.error or cube_info.error or global_config.error
 
 
 def _process_formation(
@@ -330,12 +393,14 @@ def _process_formation(
         formation_name=formation_name,
         cube_name=cube_name,
     )
+    error = _resolve_error_block(global_config, cube_info, formation_settings)
     return _create_formation_attributes(
         interval_groups=interval_groups,
         cube_info=cube_info,
         cubes=cubes,
         surfaces=surfaces,
         global_config=global_config,
+        error=error,
     )
 
 

--- a/src/fmu/sim2seis/utilities/sim2seis_class_definitions.py
+++ b/src/fmu/sim2seis/utilities/sim2seis_class_definitions.py
@@ -18,6 +18,7 @@ from typing import (
 
 import numpy as np
 import xtgeo
+from pydantic import BaseModel, ConfigDict, model_validator
 
 if TYPE_CHECKING:
     from .interval_parser import CubeConfig
@@ -45,6 +46,47 @@ KnownAttributes = Literal[
     "upper",
     "lower",
 ]
+
+ErrorType = Literal["relative", "absolute"]
+
+
+class ErrorConfig(BaseModel):
+    """Observation error settings for observed-data attribute maps.
+
+    The error is either a single scalar ``value`` or a spatially varying
+    ``error_surface`` (a file readable by xtgeo, with the same geometry as the
+    attribute maps). ``type`` decides whether the error is interpreted as a
+    fraction of the attribute value (``relative``) or as the error itself
+    (``absolute``). ``minimum`` is an absolute floor applied after the error is
+    computed.
+
+    ``error_surface`` is given in the interval definition file as a plain file
+    name relative to the global ``error_path``. It is resolved to an absolute
+    path (and its existence verified) during validation of the whole
+    configuration, in ``interval_parser.RootConfig.resolve_error_surfaces``.
+    By the time an ``ErrorConfig`` reaches the attribute-export code the field
+    therefore holds an absolute path.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    type: ErrorType
+    value: float | None = None
+    error_surface: Path | None = None
+    minimum: float = 0.0
+
+    @model_validator(mode="after")
+    def validate_source(self) -> ErrorConfig:
+        if (self.value is None) == (self.error_surface is None):
+            raise ValueError(
+                "Error configuration requires exactly one of 'value' or "
+                "'error_surface' to be set."
+            )
+        if self.value is not None and self.value < 0:
+            raise ValueError("Error 'value' must be a non-negative number.")
+        if self.minimum < 0:
+            raise ValueError("Error 'minimum' must be a non-negative number.")
+        return self
 
 
 class SeismicDate:
@@ -358,6 +400,7 @@ class SeismicAttribute:
     top_surface_shift: float = 0.0  # Use signed values for shift
     bottom_surface_shift: float = 0.0  # Use signed values for shift
     info: CubeConfig | None = None
+    error: ErrorConfig | None = None
 
     def __post_init__(self):
         # Need to verify that either a base surface or a window length is defined

--- a/src/fmu/sim2seis/utilities/sim2seis_config_validation.py
+++ b/src/fmu/sim2seis/utilities/sim2seis_config_validation.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Self, get_args
 
-import xtgeo
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -311,20 +310,6 @@ class WebvizMap(BaseModel):
         description="The file name for region definition file, 'roff' format is "
         "normally used",
     )
-    attribute_error: float | Path = Field(
-        description="Attribute error is normally given as a fractional number, "
-        "but it can also be given as a surface with polygon information "
-        "where each polygon has its own attribute error. Full path and "
-        "name to the surface file must be given, and the file format "
-        "must be recognised by xtgeo. NB! This only applies to observed data. "
-        "Modelled data are written without error.",
-        default=0.0,
-    )
-    attribute_error_minimum: float = Field(
-        description="A float value that will give the minimum error for observed data",
-        default=0.005,
-        gt=0.0,
-    )
 
     @staticmethod
     def _resolve_grid_path(v: str, info: ValidationInfo) -> tuple[Path, bool]:
@@ -357,19 +342,6 @@ class WebvizMap(BaseModel):
         if should_validate and not full_name.is_file():
             raise ValueError(f"WebvizMap: {full_name!s} is not a file")
         return Path(v)
-
-    @field_validator("attribute_error", mode="before")
-    def attribute_error_check(cls, v: float | Path):
-        if isinstance(v, float):
-            assert v >= 0.0
-            assert v <= 1.0
-            return v
-        assert v.is_file()
-        try:
-            _ = xtgeo.surface_from_file(v)
-        except ValueError:
-            raise ValueError(f"attribute error surface file not recognised: {v}")
-        return v
 
 
 class InversionParameters(BaseModel):
@@ -505,7 +477,14 @@ class Sim2SeisConfig(BaseModel):
     seismic_inversion: SkipJsonSchema[SeismicInversionConfig] = Field(
         default_factory=SeismicInversionConfig,
     )
-    webviz_map: SkipJsonSchema[WebvizMap]
+    webviz_map: SkipJsonSchema[WebvizMap] = Field(default_factory=WebvizMap)
+
+    @field_validator("webviz_map", mode="before")
+    @classmethod
+    def _default_webviz_map(cls, v):
+        # An empty ``webviz_map:`` block in the YAML parses to ``None``; fall
+        # back to the default WebvizMap in that case.
+        return {} if v is None else v
 
     @model_validator(mode="after")
     def check_sim2seis_config(self) -> Self:

--- a/tests/data/sim2seis/model/data_intervals_drogon.yml
+++ b/tests/data/sim2seis/model/data_intervals_drogon.yml
@@ -6,9 +6,19 @@ global:
     - min
   scale_factor: 1.02
   surface_postfix: --depth.gri
+  error_path: share/results/maps # directory for error surface files (global only)
+  error: # observation error for observed-data attribute maps (observed data only)
+    type: relative # 'relative' (fraction of attribute) or 'absolute'
+    value: 0.07 # single scalar; use 'error_surface' instead for a spatially varying error
+    minimum: 0.005 # absolute floor applied after the error is computed
 cubes: # Setup for the cubes for which maps will be generated
   relai_depth: # arbitrary name of cube
     cube_prefix: seismic--relai_full_depth-- # start of observed cube name
+    # A cube- or formation-level 'error' block fully replaces the global one, e.g.:
+    # error:
+    #   type: absolute
+    #   error_surface: relai_error.gri # resolved against global 'error_path'
+    #   minimum: 0.005
     formations: # settings for each formation maps will be generated for
       volantis:
         top_horizon: topvolantis # Horizon used as top of the formation. ".gri" assumed as extension

--- a/tests/data/sim2seis/model/sim2seis_combined_config.yml
+++ b/tests/data/sim2seis/model/sim2seis_combined_config.yml
@@ -102,8 +102,6 @@ webviz_map:
   # grid_file: simgrid_maps4ahm.roff
   # zone_file: simgrid_maps4ahm--zone.roff
   # region_file: simgrid_maps4ahm--region.roff
-  attribute_error: 0.07
-  attribute_error_minimum: 0.005
 
 
 ########################################################################################################################

--- a/tests/data/sim2seis/model/sim2seis_config.yml
+++ b/tests/data/sim2seis/model/sim2seis_config.yml
@@ -82,8 +82,6 @@ webviz_map:
   # grid_file: simgrid_maps4ahm.roff
   # zone_file: simgrid_maps4ahm--zone.roff
   # region_file: simgrid_maps4ahm--region.roff
-  attribute_error: 0.07
-  attribute_error_minimum: 0.005
 
 
 

--- a/tests/test_build_error_surface.py
+++ b/tests/test_build_error_surface.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+import xtgeo
+
+from fmu.sim2seis.utilities.export_with_dataio import _build_error_surface
+from fmu.sim2seis.utilities.sim2seis_class_definitions import ErrorConfig
+
+
+def _surface(values, ncol=3, nrow=3):
+    return xtgeo.RegularSurface(
+        ncol=ncol,
+        nrow=nrow,
+        xori=0.0,
+        yori=0.0,
+        xinc=1.0,
+        yinc=1.0,
+        values=np.array(values, dtype=float),
+    )
+
+
+@pytest.fixture
+def attribute_map():
+    return _surface([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+
+
+def test_relative_scalar(attribute_map):
+    err = _build_error_surface(attribute_map, ErrorConfig(type="relative", value=0.1))
+    np.testing.assert_allclose(err.values, np.abs(attribute_map.values * 0.1))
+
+
+def test_absolute_scalar(attribute_map):
+    err = _build_error_surface(attribute_map, ErrorConfig(type="absolute", value=0.25))
+    np.testing.assert_allclose(err.values, 0.25)
+
+
+def test_relative_surface(attribute_map, tmp_path):
+    error_surface = _surface([[2.0] * 3] * 3)
+    path = tmp_path / "err.gri"
+    error_surface.to_file(path)
+    err = _build_error_surface(
+        attribute_map, ErrorConfig(type="relative", error_surface=path)
+    )
+    np.testing.assert_allclose(err.values, np.abs(attribute_map.values * 2.0))
+
+
+def test_absolute_surface(attribute_map, tmp_path):
+    error_surface = _surface([[0.5, 1.0, 1.5], [2.0, 2.5, 3.0], [3.5, 4.0, 4.5]])
+    path = tmp_path / "err.gri"
+    error_surface.to_file(path)
+    err = _build_error_surface(
+        attribute_map, ErrorConfig(type="absolute", error_surface=path)
+    )
+    np.testing.assert_allclose(err.values, error_surface.values)
+
+
+def test_geometry_mismatch_raises(attribute_map, tmp_path):
+    mismatched = _surface(np.ones((4, 3)), ncol=4, nrow=3)
+    path = tmp_path / "err.gri"
+    mismatched.to_file(path)
+    with pytest.raises(ValueError, match="same geometry"):
+        _build_error_surface(
+            attribute_map, ErrorConfig(type="absolute", error_surface=path)
+        )

--- a/tests/test_interval_parser.py
+++ b/tests/test_interval_parser.py
@@ -3,15 +3,20 @@ from unittest.mock import Mock, patch
 
 import pytest
 import xtgeo
+from pydantic import ValidationError
 
 from fmu.sim2seis.utilities import SeismicName, SingleSeismic
 from fmu.sim2seis.utilities.interval_parser import (
+    CubeConfig,
     FormationSettings,
     GlobalConfig,
+    RootConfig,
     _get_matching_cubes,
     _group_attributes_by_interval,
+    _resolve_error_block,
     populate_seismic_attributes,
 )
+from fmu.sim2seis.utilities.sim2seis_class_definitions import ErrorConfig
 
 
 @pytest.fixture
@@ -843,3 +848,151 @@ def test_attribute_with_window_length_override(
     assert len(rms_attrs) == 1
     assert mean_attrs[0].window_length == 50.0
     assert rms_attrs[0].window_length is None
+
+
+# ---------------------------------------------------------------------------
+# Observation error configuration
+# ---------------------------------------------------------------------------
+
+
+def test_error_config_requires_exactly_one_source():
+    with pytest.raises(ValidationError):
+        ErrorConfig(type="relative")  # neither value nor error_surface
+    with pytest.raises(ValidationError):
+        ErrorConfig(type="relative", value=0.1, error_surface=Path("err.gri"))
+
+
+def test_error_config_rejects_negative_values():
+    with pytest.raises(ValidationError):
+        ErrorConfig(type="relative", value=-0.1)
+    with pytest.raises(ValidationError):
+        ErrorConfig(type="absolute", value=0.1, minimum=-0.1)
+
+
+def test_error_config_rejects_unknown_type():
+    with pytest.raises(ValidationError):
+        ErrorConfig(type="bogus", value=0.1)
+
+
+def _global_config(tmp_path, **error_kwargs):
+    grid_path = tmp_path / "maps"
+    grid_path.mkdir(exist_ok=True)
+    return GlobalConfig(
+        gridhorizon_path=str(grid_path),
+        attributes=["rms"],
+        scale_factor=1.0,
+        surface_postfix="--depth.gri",
+        **error_kwargs,
+    )
+
+
+def _root_config_dict(tmp_path, error, error_path=None):
+    grid_path = tmp_path / "maps"
+    grid_path.mkdir(exist_ok=True)
+    global_section = {
+        "gridhorizon_path": str(grid_path),
+        "attributes": ["rms"],
+        "scale_factor": 1.0,
+        "surface_postfix": "--depth.gri",
+        "error": error,
+    }
+    if error_path is not None:
+        global_section["error_path"] = str(error_path)
+    return {
+        "global": global_section,
+        "cubes": {
+            "amp_depth": {
+                "cube_prefix": "seismic--amplitude_depth--",
+                "formations": {
+                    "beta": {"top_horizon": "topbeta", "bottom_horizon": "basebeta"}
+                },
+            }
+        },
+    }
+
+
+def test_error_override_precedence(tmp_path):
+    global_config = _global_config(tmp_path, error={"type": "relative", "value": 0.07})
+    cube_with_error = CubeConfig(
+        cube_prefix="x", formations={}, error={"type": "absolute", "value": 0.1}
+    )
+    cube_without_error = CubeConfig(cube_prefix="x", formations={})
+    formation_with_error = FormationSettings(
+        top_horizon="t", bottom_horizon="b", error={"type": "relative", "value": 0.2}
+    )
+    formation_without_error = FormationSettings(top_horizon="t", bottom_horizon="b")
+
+    # Formation wins over cube and global
+    resolved = _resolve_error_block(
+        global_config, cube_with_error, formation_with_error
+    )
+    assert resolved.value == 0.2
+
+    # Cube wins over global when formation has no error
+    resolved = _resolve_error_block(
+        global_config, cube_with_error, formation_without_error
+    )
+    assert resolved.value == 0.1
+
+    # Global applies when neither cube nor formation set an error
+    resolved = _resolve_error_block(
+        global_config, cube_without_error, formation_without_error
+    )
+    assert resolved.value == 0.07
+
+    # No error anywhere resolves to None
+    resolved = _resolve_error_block(
+        _global_config(tmp_path), cube_without_error, formation_without_error
+    )
+    assert resolved is None
+
+
+def test_error_surface_resolved_against_error_path(tmp_path):
+    error_dir = tmp_path / "errors"
+    error_dir.mkdir()
+    error_file = error_dir / "err.gri"
+    error_file.write_bytes(b"x")
+
+    config = _root_config_dict(
+        tmp_path,
+        error={"type": "absolute", "error_surface": "err.gri"},
+        error_path=error_dir,
+    )
+    root = RootConfig.model_validate(config)
+    assert root.global_config.error.error_surface == error_file
+
+
+def test_error_surface_missing_file_raises(tmp_path):
+    error_dir = tmp_path / "errors"
+    error_dir.mkdir()
+    config = _root_config_dict(
+        tmp_path,
+        error={"type": "absolute", "error_surface": "missing.gri"},
+        error_path=error_dir,
+    )
+    with pytest.raises(ValidationError, match="Error surface file not found"):
+        RootConfig.model_validate(config)
+
+
+def test_error_surface_without_error_path_raises(tmp_path):
+    config = _root_config_dict(
+        tmp_path, error={"type": "absolute", "error_surface": "err.gri"}
+    )
+    with pytest.raises(ValidationError, match="error_path"):
+        RootConfig.model_validate(config)
+
+
+def test_error_propagated_to_seismic_attribute(
+    real_yaml_config, mock_surfaces, mock_cubes, patch_surface_loader
+):
+    real_yaml_config["global"]["error"] = {
+        "type": "relative",
+        "value": 0.07,
+        "minimum": 0.005,
+    }
+    attrs = populate_seismic_attributes(real_yaml_config, mock_cubes, mock_surfaces)
+    assert attrs
+    assert all(a.error is not None for a in attrs)
+    assert all(a.error.type == "relative" for a in attrs)
+    assert all(a.error.value == 0.07 for a in attrs)
+    assert all(a.error.minimum == 0.005 for a in attrs)

--- a/tests/test_interval_parser.py
+++ b/tests/test_interval_parser.py
@@ -959,7 +959,7 @@ def test_error_surface_resolved_against_error_path(tmp_path):
         error_path=error_dir,
     )
     root = RootConfig.model_validate(config)
-    assert root.global_config.error.error_surface == error_file
+    assert root.global_config.error.error_surface == error_file.resolve()
 
 
 def test_error_surface_missing_file_raises(tmp_path):

--- a/tests/test_read_yaml_file.py
+++ b/tests/test_read_yaml_file.py
@@ -1,9 +1,5 @@
 from pathlib import Path
 
-import pytest
-import yaml
-from pydantic import ValidationError
-
 from fmu.sim2seis.utilities import read_yaml_file
 
 
@@ -39,36 +35,4 @@ def test_read_comb_data_yaml_file(monkeypatch, data_dir):
     )
     # Make some random validations according to default settings
     assert conf.depth_conversion.min_depth < conf.depth_conversion.max_depth
-    assert conf.webviz_map.attribute_error == 0.07
-
-
-def test_attribute_error_minimum(monkeypatch, data_dir):
-    config_dir = data_dir / "sim2seis" / "model"
-    sim2seis_config_file_name = Path("sim2seis_combined_config.yml")
-    monkeypatch.chdir(data_dir)
-
-    with open(config_dir / sim2seis_config_file_name) as fin:
-        data = yaml.safe_load(fin)
-        # Modify the config file: add `test_run = True`
-        data["webviz_map"]["attribute_error_minimum"] = -0.005
-    fout_name = config_dir / Path(
-        sim2seis_config_file_name.stem + "_test" + sim2seis_config_file_name.suffix
-    )
-    with open(fout_name, "w") as fout:
-        yaml.safe_dump(data, fout)
-    with pytest.raises(ValidationError):
-        _ = read_yaml_file(
-            sim2seis_config_file=fout_name,
-            sim2seis_config_dir=config_dir,
-            global_config_dir=Path("fmuconfig/output"),
-            global_config_file=Path("global_variables.yml"),
-            parse_inputs=True,
-        )
-    conf = read_yaml_file(
-        sim2seis_config_file=sim2seis_config_file_name,
-        sim2seis_config_dir=config_dir,
-        global_config_dir=Path("fmuconfig/output"),
-        global_config_file=Path("global_variables.yml"),
-        parse_inputs=True,
-    )
-    assert conf.webviz_map.attribute_error_minimum == 0.005
+    assert conf.attribute_map_definition_file == Path("data_intervals_drogon.yml")


### PR DESCRIPTION
## Summary

Observation error for observed-data attribute-map CSV export is now configured in the **interval definition file** instead of `webviz_map`. Error can be **relative or absolute**, given as a **single scalar value** or a **`.gri` error surface** (same geometry as the attribute maps), and can be set at the **global / cube / formation** level, with the most specific block overriding the broader ones.

Closes #94 

## Changes

- **`ErrorConfig` model** (`sim2seis_class_definitions`): `type` (`relative`/`absolute`), one of `value` or `error_surface`, plus a `minimum` floor. Added an `error` field to `SeismicAttribute`.
- **Interval parser**: `error` threaded at global/cube/formation level; `RootConfig.resolve_error_surfaces` resolves every `error_surface` against the single global `error_path`, checks existence once, and normalises the field to an absolute path. `_resolve_error_block` performs formation → cube → global precedence.
- **Export** (`export_with_dataio`): `_build_error_surface` builds the absolute error surface (four relative/absolute × scalar/surface combinations, geometry guard) and passes it to `sample_attributes_for_sim2seis`. Modelled data are still written without error (`OBS_ERROR = 0.0`).
- **Removed** the old `attribute_error` / `attribute_error_minimum` fields from `WebvizMap` and from the config fixtures.
- **Docs**: new "Error settings" section in `attribute-maps.md`.
- **Tests**: `ErrorConfig` validation, override precedence, surface resolution/missing-file/missing-`error_path` guards (via `RootConfig`), and a new `test_build_error_surface` module.

## Notes

- `error_path` is a single global setting; `error_surface` names are resolved relative to it.
- Fast unit tests pass locally (`ruff` clean). The long-running workflow tests (`test_run_sim2seis_ci.py`, `test_run_sim2seis_ert.py`) should be run in CI / manually.
