### PR TITLE
ci: change python versions to 3.11, 3.12 and 3.14

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Key namespaces: `fmu.sim2seis.seismic_fwd`, `fmu.sim2seis.seismic_inversion`,
 
 ## Technology stack
 
-- **Python ≥ 3.11**; supports 3.11, 3.12, 3.13
+- **Python ≥ 3.11**; supports 3.11, 3.12, 3.14
 - **Pydantic v2** for all configuration validation (`BaseModel`, `model_validator`,
   `field_validator`, `ValidationInfo`)
 - **ERT** (`ert.shared.plugins.plugin_manager`) for forward-model integration;

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.14"]
     name: "Test: Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Natural Language :: English",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
@@ -140,4 +140,3 @@ max-args = 10
 
 [tool.ruff.format]
 skip-magic-trailing-comma = false
-


### PR DESCRIPTION
## Summary

Change supported python versions to 3.11, 3.12 and 3.14.

`python3.11` will soon be phased out, but it still exists in older RMS environments. `python3.12` is the current `komodo` version, and `python3.14` will be the next.